### PR TITLE
Specify iOS Plugin Class

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ flutter:
       android:
         package: com.afur.flutterhtmltopdf
         pluginClass: FlutterHtmlToPdfPlugin
+      ios:
+        pluginClass: SwiftFlutterHtmlToPdfPlugin
 
 
   # To add assets to your plugin package, add an assets section, like this:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_html_to_pdf
 description: Flutter plugin for generating PDF documents from HTML code templates
-version: 0.6.0
+version: 0.6.1
 author: Artur Teodorowicz <teodorowiczartur@gmail.com>
 homepage: https://github.com/Afur/flutter_html_to_pdf
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ flutter:
         package: com.afur.flutterhtmltopdf
         pluginClass: FlutterHtmlToPdfPlugin
       ios:
-        pluginClass: SwiftFlutterHtmlToPdfPlugin
+        pluginClass: FlutterHtmlToPdfPlugin
 
 
   # To add assets to your plugin package, add an assets section, like this:


### PR DESCRIPTION
The `pubspec.yaml` file doesn't specify the iOS plugin class name, so it was not included when brought into a flutter app resulting in `MissingPluginException` when trying to create the PDF. The `pubspec.yaml` has been missing this for more than just version 0.6.0, so I'm not sure what was happening before. I noticed some podfile changes in the previous PR. I wonder if they were the cause of this popping up. Either way, adding an iOS specification to the `pubspec.yaml` file fixes this issue.